### PR TITLE
add ft_atof and convertible_to_float

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,23 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   util.h                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:20:53 by nkawaguc          #+#    #+#             */
+/*   Updated: 2024/12/11 21:43:00 by nkawaguc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef UTIL_H
+# define UTIL_H
+
+# include "include.h"
+# include "macro.h"
+# include "struct.h"
+
+double	ft_atof(const char *str);
+bool	convertible_to_float(const char *str);
+
+#endif

--- a/src/util/convertible_to_float.c
+++ b/src/util/convertible_to_float.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   convertible_to_float.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:29:14 by nkawaguc          #+#    #+#             */
+/*   Updated: 2024/12/11 21:42:01 by nkawaguc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/util.h"
+
+static int	ft_isspace(int c);
+
+bool	convertible_to_float(const char *str)
+{
+	while (ft_isspace(*str))
+		str++;
+	if (*str == '-' || *str == '+')
+		str++;
+	if (!ft_isdigit(*str))
+		return (false);
+	while (ft_isdigit(*str))
+		str++;
+	if (*str == '\0')
+		return (true);
+	if (*str != '.')
+		return (false);
+	str++;
+	if (!ft_isdigit(*str))
+		return (false);
+	while (ft_isdigit(*str))
+		str++;
+	if (*str != '\0')
+		return (false);
+	return (true);
+}
+
+static int	ft_isspace(int c)
+{
+	return (c == ' ' || (9 <= c && c <= 13));
+}
+
+// #include <stdio.h>
+// int main()
+// {
+// 	printf("%d\n", convertible_to_float("123.456"));
+// 	printf("%d\n", convertible_to_float("-123.456"));
+// 	printf("%d\n", convertible_to_float("123"));
+// 	printf("%d\n", convertible_to_float("-123.456.789"));
+// 	printf("%d\n", convertible_to_float("a"));
+// 	printf("%d\n", convertible_to_float("123a"));
+// 	printf("%d\n", convertible_to_float("123."));
+// 	printf("%d\n", convertible_to_float(".123"));
+// 	printf("%d\n", convertible_to_float("123.456.789"));
+// 	printf("%d\n", convertible_to_float("123.456 "));
+// 	printf("%d\n", convertible_to_float(" 123.456"));
+// 	printf("%d\n", convertible_to_float(" 123 .456"));
+// }

--- a/src/util/ft_atof.c
+++ b/src/util/ft_atof.c
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_atof.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/11 21:15:51 by nkawaguc          #+#    #+#             */
+/*   Updated: 2024/12/11 21:42:13 by nkawaguc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/util.h"
+
+static int	ft_isspace(int c);
+
+double	ft_atof(const char *str)
+{
+	double	integer;
+	double	decimal;
+	double	divisor;
+	int		sign;
+
+	while (ft_isspace(*str))
+		str++;
+	sign = 1;
+	if (*str == '-' || *str == '+')
+		sign = 44 - *str++;
+	integer = 0;
+	while (ft_isdigit(*str))
+		integer = integer * 10 + (*str++ - '0') * sign;
+	if (*str == '.')
+		str++;
+	decimal = 0;
+	divisor = 1;
+	while (ft_isdigit(*str))
+	{
+		decimal = decimal * 10 + (*str++ - '0') * sign;
+		divisor *= 10;
+	}
+	return (integer + decimal / divisor);
+}
+
+static int	ft_isspace(int c)
+{
+	return (c == ' ' || (9 <= c && c <= 13));
+}
+
+// #include <stdio.h>
+// #include <stdlib.h>
+// int main()
+// {
+// 	printf("%f\n", ft_atof("123.456"));
+// 	printf("%f\n", atof("123.456"));
+// 	printf("%f\n", ft_atof("-123.456"));
+// 	printf("%f\n", atof("-123.456"));
+// 	printf("%f\n", ft_atof("123"));
+// 	printf("%f\n", atof("123"));
+// 	printf("%f\n", ft_atof("-123"));
+// 	printf("%f\n", atof("-123"));
+// 	printf("%f\n", ft_atof("0.456"));
+// 	printf("%f\n", atof("0.456"));
+// 	printf("%f\n", ft_atof("-0.000456"));
+// 	printf("%f\n", atof("-0.000456"));	
+// }


### PR DESCRIPTION
# 概要
ft_atofとconvertible_to_floatを追加した
# 詳細
- ft_atof
  - [任意の長さのspace][+/-/符号なし][長さ1以上のdigit part]([.][長さ1以上のdigit part])の形式のみ対応した
  - 2e9みたいなケース（これは $2\times 10^9$ として処理される）は考えていない（そのため、オリジナルのatofとは挙動が異なる）
 - convertible_to_float
   - [任意の長さのspace][+/-/符号なし][長さ1以上のdigit part]([.][長さ1以上のdigit part])の形式である場合、trueを返す。
   - そうでない場合、falseを返す
   - convertible: `3.4`, `3`, ` +3`, `   -4.2`
   - unconvertible `3.`, `.4`, `+`, `   3.4   `, `2e9`, `4.5.6`