### PR TITLE
fixed bug about displaying cylinder base

### DIFF
--- a/include/raytracing.h
+++ b/include/raytracing.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   raytracing.h                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: marimiyahara <marimiyahara@student.42.f    +#+  +:+       +#+        */
+/*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/13 21:26:05 by marimiyahar       #+#    #+#             */
-/*   Updated: 2024/12/17 01:03:24 by marimiyahar      ###   ########.fr       */
+/*   Updated: 2024/12/20 11:17:07 by nkawaguc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,9 @@ int		intersect_sphere(t_vec origin, t_vec direction,
 int		intersect_cylinder(t_vec origin, t_vec direction,
 			t_closest_obj *find_obj);
 int		intersect_plane(t_vec origin, t_vec direction, t_closest_obj *find_obj);
+
+double	intersect_cy_top_base(t_vec direction, t_vec oc, t_object *obj);
+double	intersect_cy_bottom_base(t_vec direction, t_vec oc, t_object *obj);
 
 t_vec	subtract(t_vec v1, t_vec v2);
 t_vec	add(t_vec v1, t_vec v2);

--- a/include/raytracing.h
+++ b/include/raytracing.h
@@ -6,7 +6,7 @@
 /*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/13 21:26:05 by marimiyahar       #+#    #+#             */
-/*   Updated: 2024/12/20 11:17:07 by nkawaguc         ###   ########.fr       */
+/*   Updated: 2024/12/20 18:26:56 by nkawaguc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,28 +19,55 @@
 # include "util.h"
 # include "wrap.h"
 
-void	raytracing(t_data *data);
-int		intersect(t_vec origin, t_vec direction, t_closest_obj *find_obj);
-int		intersect_sphere(t_vec origin, t_vec direction,
-			t_closest_obj *find_obj);
-int		intersect_cylinder(t_vec origin, t_vec direction,
-			t_closest_obj *find_obj);
-int		intersect_plane(t_vec origin, t_vec direction, t_closest_obj *find_obj);
+void		raytracing(t_data *data);
+int			intersect(t_vec origin, t_vec direction, t_closest_obj *find_obj);
+int			intersect_sphere(t_vec origin, t_vec direction,
+				t_closest_obj *find_obj);
+int			intersect_cylinder(t_vec origin, t_vec direction,
+				t_closest_obj *find_obj);
+int			intersect_plane(t_vec origin, t_vec direction,
+				t_closest_obj *find_obj);
 
-double	intersect_cy_top_base(t_vec direction, t_vec oc, t_object *obj);
-double	intersect_cy_bottom_base(t_vec direction, t_vec oc, t_object *obj);
+double		intersect_cy_top_base(t_vec direction, t_vec oc, t_object *obj);
+double		intersect_cy_bottom_base(t_vec direction, t_vec oc, t_object *obj);
 
-t_vec	subtract(t_vec v1, t_vec v2);
-t_vec	add(t_vec v1, t_vec v2);
-t_vec	scale(t_vec v, double scalar);
-double	dot_product(t_vec v1, t_vec v2);
-t_vec	cross_product(t_vec v1, t_vec v2);
-t_vec	normalize(t_vec v);
+t_vec		subtract(t_vec v1, t_vec v2);
+t_vec		add(t_vec v1, t_vec v2);
+t_vec		scale(t_vec v, double scalar);
+double		dot_product(t_vec v1, t_vec v2);
+t_vec		cross_product(t_vec v1, t_vec v2);
+t_vec		normalize(t_vec v);
 
-t_color	compute_lighting(t_data *data, t_vec point, t_vec normal,
-			t_object *obj);
-void	find_nearest_object(t_list *objects, t_vec origin, t_vec direction,
-			t_closest_obj *find_obj);
-t_vec	calculate_ray_direction(t_data data, int x, int y);
+t_color		compute_lighting(t_data *data, t_vec point, t_vec normal,
+				t_object *obj);
+void		find_nearest_object(t_list *objects, t_vec origin, t_vec direction,
+				t_closest_obj *find_obj);
+t_vec		calculate_ray_direction(t_data data, int x, int y);
+
+void		hook_init(t_hook *hook);
+int			key_hook_loop(int keycode, t_data *data);
+
+void		prompt(t_data *data);
+void		prompt_elem(t_data *data);
+void		prompt_object(t_data *data);
+void		prompt_light(t_data *data);
+void		prompt_camera(t_data *data);
+
+int			key_hook_update(int keycode, t_data *data);
+int			key_hook_update_object(int keycode, t_data *data);
+int			key_hook_update_object_resize(int keycode, t_data *data);
+int			key_hook_update_object_move(int keycode, t_data *data);
+int			key_hook_update_object_rotate(int keycode, t_data *data);
+int			key_hook_update_camera(int keycode, t_data *data);
+int			key_hook_update_camera_move(int keycode, t_data *data);
+int			key_hook_update_camera_rotate(int keycode, t_data *data);
+int			key_hook_update_light(int keycode, t_data *data);
+int			key_hook_update_light_move(int keycode, t_data *data);
+int			key_hook_update_light_rotate(int keycode, t_data *data);
+
+t_object	*hook_lst_at(t_data *data, int idx);
+t_vec		rotate_x(t_vec vec, double angle);
+t_vec		rotate_y(t_vec vec, double angle);
+t_vec		rotate_z(t_vec vec, double angle);
 
 #endif

--- a/src/raytracing/intersect_cy.c
+++ b/src/raytracing/intersect_cy.c
@@ -6,7 +6,7 @@
 /*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/16 00:20:54 by marimiyahar       #+#    #+#             */
-/*   Updated: 2024/12/18 21:57:13 by nkawaguc         ###   ########.fr       */
+/*   Updated: 2024/12/20 11:17:50 by nkawaguc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 static int	check_intersect(double *t, t_object *obj, t_vec origin,
 				t_vec direction);
 static int	calc_t(t_vec d_proj, t_vec oc_proj, double *t, t_object *obj);
-static int	calc_t_again(t_vec d_proj, t_vec oc_proj,
+static int	calc_t_again(t_vec direction, t_vec oc,
 				double *t, t_object *obj);
 
 int	intersect_cylinder(t_vec origin, t_vec direction, t_closest_obj *find_obj)
@@ -80,27 +80,20 @@ static int	calc_t(t_vec d_proj, t_vec oc_proj, double *t, t_object *obj)
 	return (1);
 }
 
-static int	calc_t_again(t_vec d_proj, t_vec oc_proj, double *t, t_object *obj)
+static int	calc_t_again(t_vec direction, t_vec oc, double *t, t_object *obj)
 {
-	double	divisor;
-	t_vec	vec_from_center;
+	double	t_top;
+	double	t_bottom;
 
-	divisor = dot_product(d_proj, obj->norm_vector);
-	if (divisor == 0)
+	t_top = intersect_cy_top_base(direction, oc, obj);
+	t_bottom = intersect_cy_bottom_base(direction, oc, obj);
+	if (t_top < 0 && t_bottom < 0)
 		return (0);
-	*t = (-(dot_product(oc_proj, obj->norm_vector) + obj->height / 2)
-			/ dot_product(d_proj, obj->norm_vector));
-	vec_from_center = add(add(oc_proj, scale(d_proj, *t)),
-			scale(obj->norm_vector, obj->height / 2));
-	if (*t > 0 && sqrt(dot_product(vec_from_center, vec_from_center))
-		<= obj->radius + 1e-6)
-		return (1);
-	*t = (-(dot_product(oc_proj, obj->norm_vector) - obj->height / 2)
-			/ dot_product(d_proj, obj->norm_vector));
-	vec_from_center = add(add(oc_proj, scale(d_proj, *t)),
-			scale(obj->norm_vector, -obj->height / 2));
-	if (*t > 0 && sqrt(dot_product(vec_from_center, vec_from_center))
-		<= obj->radius + 1e-6)
-		return (1);
-	return (0);
+	if (t_top < 0)
+		*t = t_bottom;
+	else if (t_bottom < 0)
+		*t = t_top;
+	else
+		*t = fmin(t_top, t_bottom);
+	return (1);
 }

--- a/src/raytracing/intersect_cy_two_bases.c
+++ b/src/raytracing/intersect_cy_two_bases.c
@@ -1,0 +1,53 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   intersect_cy_two_bases.c                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nkawaguc <nkawaguc@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/12/20 11:05:30 by nkawaguc          #+#    #+#             */
+/*   Updated: 2024/12/20 11:18:54 by nkawaguc         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../../include/minirt.h"
+
+double	intersect_cy_top_base(t_vec direction, t_vec oc, t_object *obj)
+{
+	const double	invalid_t = -1;
+	double			t;
+	double			divisor;
+	t_vec			vec_from_center;
+
+	divisor = dot_product(direction, obj->norm_vector);
+	if (divisor == 0)
+		return (invalid_t);
+	t = -(dot_product(oc, obj->norm_vector) + obj->height / 2) / divisor;
+	if (t < 0)
+		return (invalid_t);
+	vec_from_center = add(add(oc, scale(direction, t)),
+			scale(obj->norm_vector, obj->height / 2));
+	if (sqrt(dot_product(vec_from_center, vec_from_center)) > obj->radius)
+		return (invalid_t);
+	return (t);
+}
+
+double	intersect_cy_bottom_base(t_vec direction, t_vec oc, t_object *obj)
+{
+	const double	invalid_t = -1;
+	double			t;
+	double			divisor;
+	t_vec			vec_from_center;
+
+	divisor = dot_product(direction, obj->norm_vector);
+	if (divisor == 0)
+		return (invalid_t);
+	t = -(dot_product(oc, obj->norm_vector) - obj->height / 2) / divisor;
+	if (t < 0)
+		return (invalid_t);
+	vec_from_center = add(add(oc, scale(direction, t)),
+			scale(obj->norm_vector, -obj->height / 2));
+	if (sqrt(dot_product(vec_from_center, vec_from_center)) > obj->radius)
+		return (invalid_t);
+	return (t);
+}


### PR DESCRIPTION
## 概要
円柱の面が正しく表示されないバグがあったのでそれを修正した

## バグの原因
- 円柱の2つの底面のうち、先に計算した面の結果が適切な範囲内に収まっているとき、他方の底面の衝突判定が行われないため

## 修正内容
- 2つの底面それぞれについて衝突判定を行う関数を用意して、その結果を比べてtを決定する処理に変更した
- calc_t_againの実引数をdirectionとocにする変更は既に済んでいたが、仮引数がd_projとoc_projのままだったので、directionとocに変更した

## テスト
以下のケースで正しく描画されるようになった
```
A 0.2 255,255,255
C 4.599602,3.606032,6.277669 -0.5,-0.433013,-0.75 70
L 5.0,1.5,0.0 0.3 255,255,255
sp 0.0,0.0,0.0 2.0 255,224,189
pl 0.0,-2.0,0.0 0.0,1.0,0.0 100,100,100

sp 0.5,0.5,0.0 1.5 100,149,237
cy 1.0,0.0,0.0 0.588018,0.500000,0.635794 1.5 3.0 255,0,0
sp -0.5,1.5,0.0 1.0 50,205,50
pl 0.0,0.0,-5.0 0.0,0.0,1.0 255,255,0
```
ちなみに、修正前の状態では、円柱の底面が正しく描画されないとき、円柱の法線ベクトルを逆向きにすることで正しく表示されるようになっていた。そのため、他のケースで円柱の底面が正しく描画されているとき、法線ベクトルを逆向きにしても正しく描画できるかを確認して欲しい。